### PR TITLE
refactor: API 필드명 ISO 8583 Data Element 기반으로 변경 (#17)

### DIFF
--- a/pay-pos-service/src/main/java/com/card/payment/pos/client/VanClient.java
+++ b/pay-pos-service/src/main/java/com/card/payment/pos/client/VanClient.java
@@ -6,7 +6,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@FeignClient(name = "pay-van-gateway")
+@FeignClient(name = "van-service")
 public interface VanClient {
 
     @PostMapping("/api/v1/approval/request")

--- a/pay-pos-service/src/main/java/com/card/payment/pos/controller/PaymentController.java
+++ b/pay-pos-service/src/main/java/com/card/payment/pos/controller/PaymentController.java
@@ -15,12 +15,12 @@ public class PaymentController {
     private final PaymentService paymentService;
 
     @PostMapping("/request")
-    public ResponseEntity<PaymentResponse> requestPayment(@RequestBody PaymentRequest request){
+    public ResponseEntity<PaymentResponse> requestPayment(@RequestBody PaymentRequest request) {
         return ResponseEntity.ok(paymentService.requestPayment(request));
     }
 
-    @GetMapping("/{approvalId}")
-    public ResponseEntity<PaymentResponse> getPaymentResult(@PathVariable String approvalId) {
-        return ResponseEntity.ok(paymentService.getPaymentResult(approvalId));
+    @GetMapping("/{stan}")
+    public ResponseEntity<PaymentResponse> getPaymentResult(@PathVariable String stan) {
+        return ResponseEntity.ok(paymentService.getPaymentResult(stan));
     }
 }

--- a/pay-pos-service/src/main/java/com/card/payment/pos/dto/PaymentRequest.java
+++ b/pay-pos-service/src/main/java/com/card/payment/pos/dto/PaymentRequest.java
@@ -1,14 +1,9 @@
 package com.card.payment.pos.dto;
 
-import lombok.Builder;
-import lombok.Getter;
-
-import java.time.LocalDateTime;
-
 public record PaymentRequest(
-        String cardNumber,
-        String expiryDate,
-        Long amount,
-        String merchantId,
+        String primaryAccountNumber,    // DE02 - 카드번호
+        String expirationDate,          // DE14 - 유효기간
+        Long transactionAmount,         // DE04 - 거래금액
+        String cardAcceptorId,          // DE42 - 가맹점ID
         int installmentMonths
 ) {}

--- a/pay-pos-service/src/main/java/com/card/payment/pos/dto/PaymentResponse.java
+++ b/pay-pos-service/src/main/java/com/card/payment/pos/dto/PaymentResponse.java
@@ -2,20 +2,18 @@ package com.card.payment.pos.dto;
 
 import java.time.LocalDateTime;
 
-public record PaymentResponse (
-        String approvalId,
-        String status,
-        String message,
+public record PaymentResponse(
+        String systemTraceAuditNumber,  // DE11 - 거래 고유번호
+        String responseCode,            // DE39 - 응답코드
+        String responseMessage,
         LocalDateTime approvedAt,
-        String cardCompany) {
-    public static PaymentResponse from (
-            String approvalId, String status,
-            String message, String cardCompany) {
+        String cardCompany
+) {
+    public static PaymentResponse from(
+            String stan, String responseCode,
+            String responseMessage, String cardCompany) {
         return new PaymentResponse(
-                approvalId,
-                status,
-                message,
-                LocalDateTime.now(),
-                cardCompany);
+                stan, responseCode, responseMessage,
+                LocalDateTime.now(), cardCompany);
     }
 }

--- a/pay-pos-service/src/main/java/com/card/payment/pos/entity/PaymentHistory.java
+++ b/pay-pos-service/src/main/java/com/card/payment/pos/entity/PaymentHistory.java
@@ -1,39 +1,39 @@
 package com.card.payment.pos.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-@Getter
 @Entity
+@Getter
 @NoArgsConstructor
 public class PaymentHistory {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String approvalId;
-    private String cardNumber;
-    private Long amount;
-    private String status;
+    private String systemTraceAuditNumber;
+    private String primaryAccountNumber;
+    private Long transactionAmount;
+    private String responseCode;
     private String cardCompany;
-    private String merchantId;
+    private String cardAcceptorId;
     private LocalDateTime createdAt;
 
     @Builder
-    public PaymentHistory(String approvalId, String cardNumber, Long amount, String status, String cardCompany, String merchantId) {
-        this.approvalId = approvalId;
-        this.cardNumber = cardNumber;
-        this.amount = amount;
-        this.status = status;
+    public PaymentHistory(String systemTraceAuditNumber, String primaryAccountNumber,
+                          Long transactionAmount, String responseCode,
+                          String cardCompany, String cardAcceptorId) {
+        this.systemTraceAuditNumber = systemTraceAuditNumber;
+        this.primaryAccountNumber = primaryAccountNumber;
+        this.transactionAmount = transactionAmount;
+        this.responseCode = responseCode;
         this.cardCompany = cardCompany;
-        this.merchantId = merchantId;
+        this.cardAcceptorId = cardAcceptorId;
         this.createdAt = LocalDateTime.now();
     }
 }

--- a/pay-pos-service/src/main/java/com/card/payment/pos/entity/PaymentHistoryRepository.java
+++ b/pay-pos-service/src/main/java/com/card/payment/pos/entity/PaymentHistoryRepository.java
@@ -1,14 +1,9 @@
 package com.card.payment.pos.entity;
 
-
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
-@Repository
 public interface PaymentHistoryRepository extends JpaRepository<PaymentHistory, Long> {
-
-    Optional<PaymentHistory> findByApprovalId(String approvalId);
-
+    Optional<PaymentHistory> findBySystemTraceAuditNumber(String systemTraceAuditNumber);
 }

--- a/pay-pos-service/src/main/java/com/card/payment/pos/service/PaymentService.java
+++ b/pay-pos-service/src/main/java/com/card/payment/pos/service/PaymentService.java
@@ -11,36 +11,36 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class PaymentService {
+
     private final VanClient vanClient;
     private final PaymentHistoryRepository paymentHistoryRepository;
 
     public PaymentResponse requestPayment(PaymentRequest request) {
-        // 1. VaN 서비스에 승인 요청
+        // 1. VAN 서비스에 승인 요청
         PaymentResponse response = vanClient.requestApproval(request);
 
         // 2. 결제 이력 저장
-        paymentHistoryRepository.save(
-                PaymentHistory.builder()
-                        .approvalId(response.approvalId())
-                        .cardNumber(maskCardNumber(request.cardNumber()))
-                        .amount(request.amount())
-                        .status(response.status())
-                        .cardCompany(response.cardCompany())
-                        .merchantId(request.merchantId())
-                        .build()
-        );
+        PaymentHistory history = PaymentHistory.builder()
+                .systemTraceAuditNumber(response.systemTraceAuditNumber())
+                .primaryAccountNumber(maskCardNumber(request.primaryAccountNumber()))
+                .transactionAmount(request.transactionAmount())
+                .responseCode(response.responseCode())
+                .cardCompany(response.cardCompany())
+                .cardAcceptorId(request.cardAcceptorId())
+                .build();
 
-        // 3. 결과 반환
+        paymentHistoryRepository.save(history);
+
         return response;
     }
 
-    public PaymentResponse getPaymentResult(String approvalId) {
-        PaymentHistory history = paymentHistoryRepository.findByApprovalId(approvalId)
-                .orElseThrow(() -> new RuntimeException("결제 내역을 찾을 수 없습니다: " + approvalId));
+    public PaymentResponse getPaymentResult(String stan) {
+        PaymentHistory history = paymentHistoryRepository.findBySystemTraceAuditNumber(stan)
+                .orElseThrow(() -> new RuntimeException("결제 내역을 찾을 수 없습니다: " + stan));
 
         return PaymentResponse.from(
-                history.getApprovalId(),
-                history.getStatus(),
+                history.getSystemTraceAuditNumber(),
+                history.getResponseCode(),
                 "조회 완료",
                 history.getCardCompany()
         );
@@ -49,5 +49,4 @@ public class PaymentService {
     private String maskCardNumber(String cardNumber) {
         return cardNumber.substring(0, 4) + "-****-****-" + cardNumber.substring(cardNumber.length() - 4);
     }
-
 }


### PR DESCRIPTION
## 📌 관련 Issue
closes #17

## 📝 변경 사항
- PaymentRequest DTO 필드명 ISO 8583 기반으로 변경 (cardNumber → primaryAccountNumber 등)
- PaymentResponse DTO 필드명 변경 (approvalId → systemTraceAuditNumber, status → responseCode 등)
- PaymentHistory Entity 필드명 전체 변경
- PaymentHistoryRepository 쿼리 메서드명 변경 (findByApprovalId → findBySystemTraceAuditNumber)
- PaymentService 필드 참조 전체 수정
- PaymentController PathVariable 변경 (approvalId → stan)

## 🧪 테스트
- [ ] 단위 테스트 작성
- [x] 수동 테스트 확인
- [ ] 관련 서비스 연동 테스트 (VAN 서비스 완성 후)

## 🔧 영향 범위
- [x] POS 서비스
- [ ] VAN 서비스
- [ ] 인프라 (Eureka / Gateway / Config)
- [ ] 없음

## 📷 스크린샷 (선택)

## ✅ PR 머지 전 체크리스트
- [x] 브랜치명 규칙 확인 (`feature/#이슈번호-설명`)
- [x] 커밋 메시지 규칙 확인
- [x] `closes #이슈번호` 명시