### PR TITLE
[Feature] 결제 승인 및 결과 조회 API 엔드포인트 구현 #23

### DIFF
--- a/pay-van-gateway/src/main/java/com/card/payment/van/controller/PaymentController.java
+++ b/pay-van-gateway/src/main/java/com/card/payment/van/controller/PaymentController.java
@@ -1,28 +1,28 @@
-//package com.card.payment.van.controller;
-//
-//import com.card.payment.van.dto.PosPaymentRequest;
-//import com.card.payment.van.dto.PosPaymentResponse;
-//import com.card.payment.van.service.PaymentService;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.web.bind.annotation.*;
-//
-//@RestController
-//@RequiredArgsConstructor
-//@RequestMapping("/api/v1/van/approval") // VAN 게이트웨이임을 명시하기 위해 경로 조정
-//public class PaymentController {
-//
-//    private final PaymentService paymentService;
-//
-//    // POS 서비스로부터 결제 승인 요청을 받는 엔드포인트
-//    @PostMapping("/request")
-//    public ResponseEntity<PosPaymentResponse> approvePayment(@RequestBody PosPaymentRequest request) {
-//        return ResponseEntity.ok(paymentService.approvePayment(request));
-//    }
-//
-//    // 특정 거래 ID로 결제 결과 조회 (필요 시)
-//    @GetMapping("/{transactionId}")
-//    public ResponseEntity<PosPaymentResponse> getPaymentResult(@PathVariable String transactionId) {
-//        return ResponseEntity.ok(paymentService.getPaymentResult(transactionId));
-//    }
-//}
+package com.card.payment.van.controller;
+
+import com.card.payment.van.dto.PosPaymentRequest;
+import com.card.payment.van.dto.PosPaymentResponse;
+import com.card.payment.van.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/van/approval") // VAN 게이트웨이임을 명시하기 위해 경로 조정
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    // POS 서비스로부터 결제 승인 요청을 받는 엔드포인트
+    @PostMapping("/request")
+    public ResponseEntity<PosPaymentResponse> approvePayment(@RequestBody PosPaymentRequest request) {
+        return ResponseEntity.ok(paymentService.approvePayment(request));
+    }
+
+    // 특정 거래 ID로 결제 결과 조회
+    @GetMapping("/{transactionId}")
+    public ResponseEntity<PosPaymentResponse> getPaymentResult(@PathVariable String transactionId) {
+        return ResponseEntity.ok(paymentService.getPaymentResult(transactionId));
+    }
+}


### PR DESCRIPTION
## 📌 개요
- POS 서비스로부터의 결제 승인 요청을 수신하고, 거래 결과를 조회할 수 있는 API 엔드포인트 구현
- 서비스 식별을 위한 Base Path 최적화

## ✅ 작업 내용
- 결제 승인 요청 수신용 `@PostMapping("/request")` 엔드포인트 구현
- 거래 ID 기반 결제 결과 조회용 `@GetMapping("/{transactionId}")` 인터페이스 선행 정의
- 서비스 구분을 위해 `@RequestMapping` 경로를 `/api/v1/van/approval`로 조정
- `PaymentService`와의 호출 로직 연동

## 📎 관련 문서
- `pay-pos-service` 모듈의 `VanClient.java`와 경로 동기화 필요

## 🔗 관련 Issue
- closes #23