### PR TITLE
paymentRequest 필드 누락 수정

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,6 +7,7 @@
 | @author | 날짜/시각 | 변경 내용 |
 |---------|-----------|-----------|
 | 개발자1 | 2026.03.20.16.00 | 최초 작성 - cardCompany 설계 오류 및 해결 과정 기록 |
+| 개발자1 | 2026.03.20.17.00 | POS PaymentRequest terminalId, posOrderId 누락 이슈 추가 |
 
 ---
 
@@ -59,3 +60,51 @@ private String resolveCardCompany(String primaryAccountNumber) {
 - 각 서비스의 책임 범위를 명확히 할 것
 - **카드사**: 카드 유효성 검증 및 승인/거절 처리만 담당
 - **VAN**: BIN 라우팅, 카드사 식별, 필드 변환 담당
+
+---
+
+## [POS-001] PaymentRequest에 terminalId, posOrderId 필드 누락
+
+### 발생 배경
+
+POS ↔ VAN 스펙 합의 후 `PaymentRequest`에 `terminalId`, `posOrderId` 필드를 추가했으나, 이후 코드 수정 과정에서 해당 필드들이 주석으로만 남고 실제 필드가 누락됨.
+
+### 문제점
+
+```java
+// 누락된 상태
+public record PaymentRequest(
+        String primaryAccountNumber,
+        String expirationDate,
+        Long transactionAmount,
+        String cardAcceptorId,
+        // DE41 - 단말기 ID (선택, 없으면 null)   ← 필드 없이 주석만 존재
+        int installmentMonths
+        // POS 주문 ID                             ← 필드 없이 주석만 존재
+) {}
+```
+
+VAN의 `PosPaymentRequest`에는 `posOrderId`가 있고 `PaymentHistory`에 `nullable = false`로 설정되어 있어서 요청 시 500 에러 발생.
+
+```
+PropertyValueException: not-null property references a null or transient value: PaymentHistory.posOrderId
+```
+
+### 해결
+
+```java
+public record PaymentRequest(
+        String primaryAccountNumber,    // DE02 - 카드번호
+        String expirationDate,          // DE14 - 유효기간
+        Long transactionAmount,         // DE04 - 거래금액
+        String cardAcceptorId,          // DE42 - 가맹점ID
+        String terminalId,              // DE41 - 단말기 ID (선택, 없으면 null)
+        int installmentMonths,          // 할부 개월수
+        String posOrderId               // POS 주문 ID
+) {}
+```
+
+### 교훈
+
+- POS ↔ VAN 스펙 합의 후 양쪽 DTO 필드가 동일한지 반드시 대조 확인할 것
+- 주석으로만 남긴 필드는 실제 코드에 반영되지 않으므로 주의

--- a/pay-pos-service/src/main/java/com/card/payment/pos/dto/PaymentRequest.java
+++ b/pay-pos-service/src/main/java/com/card/payment/pos/dto/PaymentRequest.java
@@ -5,7 +5,7 @@ public record PaymentRequest(
         String expirationDate,          // DE14 - 유효기간
         Long transactionAmount,         // DE04 - 거래금액
         String cardAcceptorId,          // DE42 - 가맹점ID
-        // DE41 - 단말기 ID (선택, 없으면 null)
-        int installmentMonths          // 할부 개월수
-        // POS 주문 ID
+        String terminalId,              // DE41 - 단말기 ID (선택, 없으면 null)
+        int installmentMonths,          // 할부 개월수
+        String posOrderId               // POS 주문 ID
 ) {}


### PR DESCRIPTION
## 📌 관련 Issue
closes #

## 📝 변경 사항
필드 추가
```
       81 +        // DE41 - 단말기 ID (선택, 없으면 null)   ← 필드 없이 주석만 존재
       82 +        int installmentMonths
       83 +        // POS 주문 ID                             ← 필드 없이 주석만 존재 
```
## 🧪 테스트
- [ ] 단위 테스트 작성
- [ ] 수동 테스트 확인
- [ ] 관련 서비스 연동 테스트 (해당 시)

## 🔧 영향 범위
- [x] POS 서비스
- [x] VAN 서비스
- [x] 인프라 (Eureka / Gateway / Config)
- [ ] 없음

## 📷 스크린샷 (선택)

## ✅ PR 머지 전 체크리스트
- [x] 브랜치명 규칙 확인 (`feature/#이슈번호-설명`)
- [x] 커밋 메시지 규칙 확인
- [x] `closes #이슈번호` 명시